### PR TITLE
Update writable params

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -12,6 +12,7 @@ const WRITABLE_TASK_DEF_PARAMS = [
   'family',
   'placementConstraints',
   'volumes',
+  'taskRoleArn',
 ];
 
 // ECS resource ARN format:


### PR DESCRIPTION
Ensure `taskRoleArn` is updated when the task definition is written. This was causing issues for the upload service which uses a role to access the `hustle-file-uploads` s3 bucket.