### PR TITLE
Disable remaining lint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,7 @@
     "extends": "airbnb",
     "rules": {
       "arrow-body-style": 0,
+      "no-await-in-loop": 0,
+      "prefer-destructuring": 0,
     }
 }

--- a/src/pecs.js
+++ b/src/pecs.js
@@ -15,7 +15,7 @@ const {
 } = require('./actions');
 
 process.on('unhandledRejection', (e) => {
-  console.error(e);
+  console.error(e); // eslint-disable-line no-console
   process.exit(1);
 });
 


### PR DESCRIPTION
We've done well at keeping our other repos lint-clean, so when I get the squiggly lines on this one, it's particularly distracting. Now there are none! :sparkles: 