### PR TITLE
Preserve executionRoleArn when updating a task def

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -13,6 +13,7 @@ const WRITABLE_TASK_DEF_PARAMS = [
   'placementConstraints',
   'volumes',
   'taskRoleArn',
+  'executionRoleArn',
 ];
 
 // ECS resource ARN format:


### PR DESCRIPTION
The new `executionRoleArn` top-level attribute needs to be preserved
when updating a task definition. Otherwise it's not possible to update
task definitions that contain secrets.

Tested by running:
```
pecs config set ROHAN_TEST foo -c dev-cluster -s api
```

Previously that would throw an error complaining about
`executionRoleArn`. But now it succeeds.